### PR TITLE
bugfix[?] in equal time energy correlator

### DIFF
--- a/src/dqmc.c
+++ b/src/dqmc.c
@@ -109,7 +109,7 @@ static int dqmc(struct sim_data *sim)
 	num *const restrict gdacc = my_calloc(N*N * sizeof(num));
 	#endif
 	num phase;
-	int *const site_order = my_calloc(N * sizeof(double));
+	int *const site_order = my_calloc(N * sizeof(int));
 
 	// work arrays for calc_eq_g and stuff. two sets for easy 2x parallelization
 	num *const restrict tmpNN1u = my_calloc(N*N * sizeof(num));

--- a/src/meas.c
+++ b/src/meas.c
@@ -65,8 +65,8 @@ void measure_eqlt(const struct params *const restrict p, const num phase,
 		m->zz[r] += 0.25*pre*((gdii - guii)*(gdjj - gujj) + x);
 		m->pair_sw[r] += pre*guij*gdij;
 		if (meas_energy_corr) {
-			const double nuinuj = (1. - guii)*(1. - gujj) + (delta - guji)*guij;
-			const double ndindj = (1. - gdii)*(1. - gdjj) + (delta - gdji)*gdij;
+			const num nuinuj = (1. - guii)*(1. - gujj) + (delta - guji)*guij;
+			const num ndindj = (1. - gdii)*(1. - gdjj) + (delta - gdji)*gdij;
 			m->vv[r] += pre*nuinuj*ndindj;
 			m->vn[r] += pre*(nuinuj*(1. - gdii) + (1. - guii)*ndindj);
 		}


### PR DESCRIPTION
should not be assigning complex rhs to double lhs